### PR TITLE
ci: fix zizmor security findings across workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,14 +10,14 @@ updates:
     schedule:
       interval: "daily"
     cooldown:
-      default-days: 5
+      default-days: 7
 
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "daily"
     cooldown:
-      default-days: 5
+      default-days: 7
       semver-major-days: 30
       semver-minor-days: 7
-      semver-patch-days: 3
+      semver-patch-days: 7

--- a/.github/workflows/ci_main.yml
+++ b/.github/workflows/ci_main.yml
@@ -9,9 +9,13 @@ on:
   pull_request:
     branches: [main]
 
+permissions: {}
+
 jobs:
   unit_test:
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
 
     strategy:
       matrix:
@@ -19,6 +23,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     branches: [main]
 
+permissions: {}
+
 jobs:
   demo_page:
     runs-on: ubuntu-22.04
@@ -13,6 +15,8 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Use Node.js
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:


### PR DESCRIPTION
## Summary

Fix all open zizmor Code Scanning alerts found after adding zizmor audit workflow (#308).

**Changes:**
- `ci_main.yml`: Add top-level `permissions: {}` and job-level `contents: read`; add `persist-credentials: false` to checkout
- `gh-pages.yml`: Add top-level `permissions: {}`; add `persist-credentials: false` to checkout
- `dependabot.yml`: Increase cooldown `default-days` from 5 to 7 and `semver-patch-days` from 3 to 7

**Unchanged:**
- `npm_publish.yml` (already clean)
- `zizmor.yml` (already clean)

### Resolved Alerts

| Alert | Rule | File |
|-------|------|------|
| #7 | `artipacked` | ci_main.yml |
| #8 | `excessive-permissions` | ci_main.yml |
| #9 | `artipacked` | gh-pages.yml |
| #5, #6 | `dependabot-cooldown` | dependabot.yml |

## Test plan

- [ ] CI passes
- [ ] zizmor scan shows no new findings
- [ ] Existing alerts transition to "fixed" in Code Scanning after merge

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Extended Dependabot dependency update review cycles from 5 to 7 days
* Restricted GitHub Actions default token permissions across workflows
* Enhanced credential handling security in continuous integration processes by disabling automatic credential persistence

<!-- end of auto-generated comment: release notes by coderabbit.ai -->