### PR TITLE
build(deps): bump upload-artifact to v7.0.0 and download-artifact to v8.0.1

### DIFF
--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -128,7 +128,7 @@ jobs:
       - name: Pack
         run: npm pack
       - name: Upload package artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: masatomakino-tween.js-ticker
           path: "*.tgz"
@@ -142,7 +142,7 @@ jobs:
       id-token: write
     steps:
       - name: Download package artifact
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: masatomakino-tween.js-ticker
       - name: Use Node.js


### PR DESCRIPTION
## Summary

Consolidates Dependabot PRs #310 and #311 into a single update to keep upload/download artifact actions in sync.

**Scope:**
- `actions/upload-artifact`: v4.6.2 → v7.0.0
- `actions/download-artifact`: v4.3.0 → v8.0.1

**SHA verification:** Both commit SHAs independently verified against GitHub API (`git/ref/tags/`).

**Unchanged:**
- Workflow logic, artifact name, retention settings

## Test plan

- [ ] CI passes (unit tests, zizmor, demo page)
- [ ] Verify `workflow_dispatch` publish pipeline works on next release

Closes #310
Closes #311

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions dependencies used in the npm publish workflow to latest versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->