### PR TITLE
chore: Update Node.js CI matrix to supported LTS versions

### DIFF
--- a/.github/workflows/ci_main.yml
+++ b/.github/workflows/ci_main.yml
@@ -19,7 +19,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [22.x, 24.x]
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
-          node-version: "20"
+          node-version: "22"
           cache: "npm"
       - run: npm ci
       - name: build page


### PR DESCRIPTION
## Summary

Drop EOL Node.js versions from CI matrix and align workflows with current LTS support range.

**Changes:**
- `ci_main.yml`: Update test matrix from `[18.x, 20.x, 22.x]` to `[22.x, 24.x]`
- `gh-pages.yml`: Update demo page build from Node 20 to 22

**Unchanged:**
- `npm_publish.yml`: Remains at Node 22

## Test plan

- [ ] CI matrix runs successfully on Node 22.x and 24.x
- [ ] GitHub Pages build succeeds with Node 22

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD pipelines to test and build with newer Node.js runtime versions for improved compatibility with current development standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->